### PR TITLE
Ensure SSH keys are Copied with Correct Formatting

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -37,7 +37,8 @@ git remote add origin "$GIT_REPO_URL"
 # install the ssh key
 mkdir -p ~/.ssh
 ssh-keyscan -H github.com >> ~/.ssh/known_hosts 2> /dev/null
-cat "$ENV_DIR/GIT_SSH_KEY" > ~/.ssh/id_rsa
+cp "$ENV_DIR/GIT_SSH_KEY" ~/.ssh/id_rsa
+echo >> ~/.ssh/id_rsa
 chmod 600 ~/.ssh/id_rsa
 
 # ignore/hide ssh warnings


### PR DESCRIPTION
I ran into some issues using this buildpack where my keys were being copied to the dyno and rejected by the SSH agent, likely because they were shoved onto one line and the file didn't end in a newline. I've found that this change correctly moved my ED25519 deploy keys onto the dyno and allowed by slugs to compile.