### PR TITLE
allow using buildback in CI tests

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -9,6 +9,8 @@ GIT_SSH_KEY=$(<"$ENV_DIR/GIT_SSH_KEY")
 SOURCE_VERSION=$(<"$ENV_DIR/SOURCE_VERSION")
 CI=$(<"$ENV_DIR/CI")
 HEROKU_TEST_RUN_BRANCH=$(<"$ENV_DIR/HEROKU_TEST_RUN_BRANCH")
+echo "listing ENV_DIR"
+ls -lah $ENV_DIR
 
 if [[ -z $GIT_REPO_URL ]]; then
     echo "Did you forget to set GIT_REPO_URL?"

--- a/bin/compile
+++ b/bin/compile
@@ -9,6 +9,7 @@ GIT_SSH_KEY=$(<"$ENV_DIR/GIT_SSH_KEY")
 SOURCE_VERSION=$(<"$ENV_DIR/SOURCE_VERSION")
 CI=$(<"$ENV_DIR/CI")
 HEROKU_TEST_RUN_BRANCH=$(<"$ENV_DIR/HEROKU_TEST_RUN_BRANCH")
+HEROKU_BRANCH=$(<"$ENV_DIR/HEROKU_BRANCH")
 echo "listing ENV_DIR"
 ls -lah $ENV_DIR
 
@@ -58,8 +59,13 @@ git fetch -q --depth 1 origin -a > /dev/null
 if [ $CI ]
 then
     git checkout -q ${HEROKU_TEST_RUN_BRANCH:-master} > /dev/null
-else 
-    git checkout -q ${SOURCE_VERSION:-master} > /dev/null
+else
+    if [ $HEROKU_BRANCH ]
+    then
+        git checkout -q ${HEROKU_BRANCH:-master} > /dev/null
+    else
+        git checkout -q ${SOURCE_VERSION:-master} > /dev/null
+    fi
 fi
 echo "-----> Fetched shallow history from $GIT_REPO_URL"
 

--- a/bin/compile
+++ b/bin/compile
@@ -6,6 +6,9 @@ ENV_DIR="$3"
 # load required environment variables
 GIT_REPO_URL=$(<"$ENV_DIR/GIT_REPO_URL")
 GIT_SSH_KEY=$(<"$ENV_DIR/GIT_SSH_KEY")
+SOURCE_VERSION=$(<"$ENV_DIR/SOURCE_VERSION")
+CI=$(<"$ENV_DIR/CI")
+HEROKU_TEST_RUN_BRANCH=$(<"$ENV_DIR/HEROKU_TEST_RUN_BRANCH")
 
 if [[ -z $GIT_REPO_URL ]]; then
     echo "Did you forget to set GIT_REPO_URL?"
@@ -50,7 +53,12 @@ echo "-----> Installed SSH key from GIT_SSH_KEY"
 
 # checkout the revision that's being deployed
 git fetch -q --depth 1 origin -a > /dev/null
-git checkout -q ${SOURCE_VERSION:-master} > /dev/null
+if [ $CI ]
+then
+    git checkout -q ${HEROKU_TEST_RUN_BRANCH:-master} > /dev/null
+else 
+    git checkout -q ${SOURCE_VERSION:-master} > /dev/null
+fi
 echo "-----> Fetched shallow history from $GIT_REPO_URL"
 
 # initialize all the submodules

--- a/bin/compile
+++ b/bin/compile
@@ -10,8 +10,6 @@ SOURCE_VERSION=$(<"$ENV_DIR/SOURCE_VERSION")
 CI=$(<"$ENV_DIR/CI")
 HEROKU_TEST_RUN_BRANCH=$(<"$ENV_DIR/HEROKU_TEST_RUN_BRANCH")
 HEROKU_BRANCH=$(<"$ENV_DIR/HEROKU_BRANCH")
-echo "listing ENV_DIR"
-ls -lah $ENV_DIR
 
 if [[ -z $GIT_REPO_URL ]]; then
     echo "Did you forget to set GIT_REPO_URL?"


### PR DESCRIPTION
This PR addresses an issue we found while attempting to use this buildpack in heroku CI where the submodule code wasn't being checked out.  

in investigating it turns out the `SOURCE_VERSION` variable is not available in CI but `HEROKU_TEST_RUN_BRANCH` is so this PR checks if `CI` is true and if so, uses `HEROKU_TEST_RUN_BRANCH` variable for the checkout command else uses the existing `SOURCE_VERSION` variable.  