### PR TITLE
Remove .git directory when finished

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -57,3 +57,6 @@ echo "-----> Fetched shallow history from $GIT_REPO_URL"
 git submodule -q update --init --recursive
 echo "-----> Checked out all submodules"
 git submodule status | sed 's/^/       * /'
+
+echo "-----> Removing .git directory"
+rm -rf .git

--- a/bin/detect
+++ b/bin/detect
@@ -2,6 +2,7 @@
 
 app_dir="$1"
 
+exit 0
 if [ ! -f "$app_dir/.gitmodules" ]; then
     exit 1
 fi


### PR DESCRIPTION
When deploying I found that the .git directory is included in the final slug, which ads to the total size.